### PR TITLE
Add pending intent mutability flag on API 23+

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 ext {
-    version_code = 3
-    version_name = '0.1.4'
+    version_code = 4
+    version_name = '0.1.5'
 
     kotlin_version = '1.5.31'
 

--- a/tellerlogger/src/main/java/com/kiliansteenman/teller/logger/ui/TellerLogNotification.kt
+++ b/tellerlogger/src/main/java/com/kiliansteenman/teller/logger/ui/TellerLogNotification.kt
@@ -96,6 +96,13 @@ class TellerLogNotification(
         context,
         NOTIFICATION_ID,
         TellerLogIntentFactory.createIntent(context),
-        PendingIntent.FLAG_UPDATE_CURRENT
+        getIntentFlags(),
     )
+
+    private fun getIntentFlags() =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        } else {
+            PendingIntent.FLAG_UPDATE_CURRENT
+        }
 }


### PR DESCRIPTION
Add pending intent mutability flag on API 23+ to fix Android 12 crashes